### PR TITLE
Add schema endpoint for single schema 

### DIFF
--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -22,11 +22,10 @@ class AllInterfaces(Resource):
                 api.abort(500, str(e))
             raise e
 
+
 @api.route("/schema/<string:interface>")
 class Schema(Resource):
-    @api.doc(
-        responses={200: "Success", 400: "Bad Request", 500: "Internal server error"}
-    )
+    @api.doc(responses={200: "Success", 400: "Bad Request", 500: "Internal server error"})
     def get(self, interface):
 
         try:

--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -1,6 +1,6 @@
 from flask_restx import Namespace, Resource, reqparse
 from namespaces import get_namespace, NamespaceEnum
-from manageNeuroconv import get_all_interface_info
+from manageNeuroconv import get_all_interface_info, get_schema
 from errorHandlers import notBadRequestException
 
 api = Namespace("neuroconv", description="Neuroconv API for NWB GUIDE")
@@ -17,6 +17,20 @@ class AllInterfaces(Resource):
 
         try:
             return get_all_interface_info()
+        except Exception as e:
+            if notBadRequestException(e):
+                api.abort(500, str(e))
+            raise e
+
+@api.route("/schema/<string:interface>")
+class Schema(Resource):
+    @api.doc(
+        responses={200: "Success", 400: "Bad Request", 500: "Internal server error"}
+    )
+    def get(self, interface):
+
+        try:
+            return get_schema(interface)
         except Exception as e:
             if notBadRequestException(e):
                 api.abort(500, str(e))

--- a/pyflask/manageNeuroconv/__init__.py
+++ b/pyflask/manageNeuroconv/__init__.py
@@ -1,1 +1,1 @@
-from .manage_neuroconv import get_all_interface_info
+from .manage_neuroconv import get_all_interface_info, get_schema

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1,5 +1,6 @@
 from neuroconv.datainterfaces import SpikeGLXRecordingInterface, PhySortingInterface
 
+
 def get_all_interface_info() -> dict:
     """Format an information structure to be used for selecting interfaces based on modality and technique."""
     # Hard coded for now - eventual goal will be to import this from NeuroConv

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -15,7 +15,7 @@ def get_all_interface_info() -> dict:
     for modality, techniques in interfaces_by_modality_and_technique.items():
         for technique, format_name_to_interface in techniques.items():
             for format_name, interface in format_name_to_interface.items():
-                
+
                 interface_info[interface.__name__] = {  # Note in the full scope, format_name won't be unique
                     "modality": modality,
                     "name": format_name,
@@ -24,6 +24,7 @@ def get_all_interface_info() -> dict:
 
     return interface_info
 
+
 def get_schema(interface):
     """
     Function used to get schema for a single interface
@@ -31,4 +32,4 @@ def get_schema(interface):
 
     # Hard coded for now - eventual goal will be to import this from NeuroConv
     interface_list_subset = [SpikeGLXRecordingInterface, PhySortingInterface]
-    return [x for x in interface_list_subset if x.__name__ == interface][0].get_source_schema() # Single Interface
+    return [x for x in interface_list_subset if x.__name__ == interface][0].get_source_schema()  # Single Interface

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1,4 +1,5 @@
 from neuroconv.datainterfaces import SpikeGLXRecordingInterface, PhySortingInterface
+from neuroconv import NWBConverter
 
 
 def get_all_interface_info() -> dict:
@@ -16,11 +17,20 @@ def get_all_interface_info() -> dict:
     for modality, techniques in interfaces_by_modality_and_technique.items():
         for technique, format_name_to_interface in techniques.items():
             for format_name, interface in format_name_to_interface.items():
-                # interface = format_name_to_interface
-                interface_info[format_name] = {  # Note in the full scope, format_name won't be unique
+                
+                interface_info[interface.__name__] = {  # Note in the full scope, format_name won't be unique
                     "modality": modality,
-                    "name": interface.__name__,  # Where is this value used in the display?
-                    "technique": technique,  # Is this actually necessary anymore?
+                    "name": format_name,
+                    "technique": technique,
                 }
 
     return interface_info
+
+def get_schema(interface):
+    """
+    Function used to get schema for a single interface
+    """
+
+    # Hard coded for now - eventual goal will be to import this from NeuroConv
+    interface_list_subset = [SpikeGLXRecordingInterface, PhySortingInterface]
+    return [x for x in interface_list_subset if x.__name__ == interface][0].get_source_schema() # Single Interface

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1,6 +1,4 @@
 from neuroconv.datainterfaces import SpikeGLXRecordingInterface, PhySortingInterface
-from neuroconv import NWBConverter
-
 
 def get_all_interface_info() -> dict:
     """Format an information structure to be used for selecting interfaces based on modality and technique."""

--- a/pyflask/tests/test_neuroconv.py
+++ b/pyflask/tests/test_neuroconv.py
@@ -10,3 +10,11 @@ def test_get_all_interfaces(client):
         assert isinstance(value["modality"], str)
         assert isinstance(value["name"], str)
         assert isinstance(value["technique"], str)
+
+# Accesses the schema for a single interface directly
+def test_single_schema_request(client):
+    response = client.get("/neuroconv/schema/PhySortingInterface", follow_redirects=True)
+    data = response.json
+    assert isinstance(data, dict)
+    assert isinstance(data['required'], list)
+    assert isinstance(data['properties'], dict)

--- a/pyflask/tests/test_neuroconv.py
+++ b/pyflask/tests/test_neuroconv.py
@@ -11,10 +11,11 @@ def test_get_all_interfaces(client):
         assert isinstance(value["name"], str)
         assert isinstance(value["technique"], str)
 
+
 # Accesses the schema for a single interface directly
 def test_single_schema_request(client):
     response = client.get("/neuroconv/schema/PhySortingInterface", follow_redirects=True)
     data = response.json
     assert isinstance(data, dict)
-    assert isinstance(data['required'], list)
-    assert isinstance(data['properties'], dict)
+    assert isinstance(data["required"], list)
+    assert isinstance(data["properties"], dict)

--- a/scripts/others/renderer.js
+++ b/scripts/others/renderer.js
@@ -8925,8 +8925,9 @@ async function handleDataFormats() {
 
   // const intentation = '\xa0\xa0\xa0\xa0'
   let modalities = {};
-  for (let name in formats) {
-    const format = formats[name];
+  for (let className in formats) {
+    const format = formats[className];
+    const name = format.name;
 
     let modality = modalities[format.modality];
     if (!modality) {


### PR DESCRIPTION
This PR introduces a basic endpoint to request the schema of a single `neuroconv` interface. Further discussion about the returned NWBConverter schema will let us add an endpoint for multiple interfaces.

An additional change was made to interface_info keys to prioritize the class name and ensure uniqueness in the future.